### PR TITLE
Sync datatype definitions

### DIFF
--- a/src/Zenon.Tests/Api/ApiTest.cs
+++ b/src/Zenon.Tests/Api/ApiTest.cs
@@ -151,7 +151,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(2, 123, "Zenon.Resources.api.embedded.bridge.getNetworkInfo.json")]
-                public async Task SingleResponseAsync(int networkClass, int chainId, string resourceName)
+                public async Task SingleResponseAsync(uint networkClass, uint chainId, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -207,7 +207,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -225,7 +225,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllWrapTokenRequests.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -253,7 +253,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string toAddress, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string toAddress, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -271,7 +271,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllWrapTokenRequestsByToAddress.json")]
-                public async Task ListResponseAsync(string toAddress, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string toAddress, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -299,7 +299,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 2, 123, 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string toAddress, int networkClass, int chainId, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string toAddress, uint networkClass, uint chainId, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -317,7 +317,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 2, 123, 0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllWrapTokenRequestsByToAddressNetworkClassAndChainId.json")]
-                public async Task ListResponseAsync(string toAddress, int networkClass, int chainId, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string toAddress, uint networkClass, uint chainId, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -345,7 +345,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -363,7 +363,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllNetworks.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -391,7 +391,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -409,7 +409,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllUnsignedWrapTokenRequests.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -437,7 +437,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("11ac76e40cc23674300f68ca87f5ebeb7210fc327fd43f35081b75a839c9c632", 200, "Zenon.Resources.api.embedded.bridge.getUnwrapTokenRequestByHashAndLog.json")]
-                public async Task SingleResponseAsync(string hash, int logIndex, string resourceName)
+                public async Task SingleResponseAsync(string hash, uint logIndex, string resourceName)
                 {
                     // Setup
                     var h = Hash.Parse(hash);
@@ -466,7 +466,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -484,7 +484,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllUnwrapTokenRequests.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -512,7 +512,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string toAddress, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string toAddress, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -530,7 +530,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("0xb794f5ea0ba39494ce839613fffba74279579268", 0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.bridge.getAllUnwrapTokenRequestsByToAddress.json")]
-                public async Task ListResponseAsync(string toAddress, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string toAddress, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new BridgeApi(new Lazy<IClient>(() => new TestClient()
@@ -618,7 +618,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -637,7 +637,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7", 0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.liquidity.getFrontierRewardByPage.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -718,7 +718,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -737,7 +737,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7", 0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.liquidity.getLiquidityStakeEntriesByAddress.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -874,7 +874,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new SporkApi(new Lazy<IClient>(() => new TestClient()
@@ -892,7 +892,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.spork.getAll.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new SporkApi(new Lazy<IClient>(() => new TestClient()
@@ -923,7 +923,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new AcceleratorApi(new Lazy<IClient>(() => new TestClient()
@@ -941,7 +941,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.accelerator.getAll.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new AcceleratorApi(new Lazy<IClient>(() => new TestClient()
@@ -1142,7 +1142,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1162,7 +1162,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.pillar.getFrontierRewardByPage.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1217,7 +1217,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1236,7 +1236,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.pillar.getAll.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1392,7 +1392,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("SultanOfStaking", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string name, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string name, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1411,7 +1411,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("SultanOfStaking", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.pillar.getPillarEpochHistory.json")]
-                public async Task ListResponseAsync(string name, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string name, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1439,7 +1439,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(140, 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int epoch, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(ulong epoch, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1458,7 +1458,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData(140, 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.pillar.getPillarsHistoryByEpoch.json")]
-                public async Task ListResponseAsync(int epoch, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(ulong epoch, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new PillarApi(new Lazy<IClient>(() => new TestClient()
@@ -1517,7 +1517,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqylpfyyrj5t8pe99n4nf4x634vxse96fg7sge", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1537,7 +1537,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqylpfyyrj5t8pe99n4nf4x634vxse96fg7sge", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.plasma.getEntriesByAddress.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1614,7 +1614,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var api = new SentinelApi(new Lazy<IClient>(() => new TestClient()
@@ -1633,7 +1633,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.sentinel.getAllActive.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new SentinelApi(new Lazy<IClient>(() => new TestClient()
@@ -1745,7 +1745,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qrg4nt69dakvw9wc3pmcvnuax70uj04wt4dxk4", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1765,7 +1765,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qrg4nt69dakvw9wc3pmcvnuax70uj04wt4dxk4", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.sentinel.getFrontierRewardByPage.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1797,7 +1797,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1817,7 +1817,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.stake.getEntriesByAddress.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1846,7 +1846,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -1866,7 +1866,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.stake.getFrontierRewardByPage.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2043,7 +2043,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(0, Constants.RpcMaxPageSize, "Zenon.Resources.api.embedded.token.getAll.json")]
-                public async Task ListResponseAsync(int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var api = new TokenApi(new Lazy<IClient>(() => new TestClient()
@@ -2072,7 +2072,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qpgdtn89u9365jr7ltdxu29fy52pnzwe4fl7zc", 0, Constants.RpcMaxPageSize,
                     "Zenon.Resources.api.embedded.token.getByOwner.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2134,7 +2134,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqylpfyyrj5t8pe99n4nf4x634vxse96fg7sge", 0, Constants.MemoryPoolPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2154,7 +2154,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqylpfyyrj5t8pe99n4nf4x634vxse96fg7sge", 0, Constants.MemoryPoolPageSize,
                     "Zenon.Resources.api.ledger.getUnconfirmedBlocksByAddress.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2183,7 +2183,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qq6g4jptwwjmp0ym38n0juru2zzygap6r42pc0", 0, Constants.MemoryPoolPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2203,7 +2203,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qq6g4jptwwjmp0ym38n0juru2zzygap6r42pc0", 0, Constants.MemoryPoolPageSize,
                     "Zenon.Resources.api.ledger.getUnreceivedBlocksByAddress.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2289,17 +2289,17 @@ namespace Zenon.Api
                 public string MethodName { get; set; }
 
                 [Theory]
-                [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 500, Constants.RpcMaxPageSize)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 500, Constants.MemoryPoolPageSize)]
+                public async Task EmptyResponseAsync(string address, ulong height, ulong count)
                 {
                     // Setup
                     var addr = Address.Parse(address);
                     var api = new LedgerApi(new Lazy<IClient>(() => new TestClient()
-                        .WithMethod(this.MethodName, addr.ToString(), pageIndex, pageSize)
+                        .WithMethod(this.MethodName, addr.ToString(), height, count)
                         .WithEmptyResponse()));
 
                     // Execute
-                    var result = await api.GetAccountBlocksByHeight(addr, pageIndex, pageSize);
+                    var result = await api.GetAccountBlocksByHeight(addr, height, count);
 
                     // Validate
                     result.Should().NotBeNull();
@@ -2310,16 +2310,16 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 500, Constants.MemoryPoolPageSize,
                     "Zenon.Resources.api.ledger.getAccountBlocksByHeight.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, ulong height, ulong count, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
                     var api = new LedgerApi(new Lazy<IClient>(() => new TestClient()
-                        .WithMethod(this.MethodName, addr.ToString(), pageIndex, pageSize)
+                        .WithMethod(this.MethodName, addr.ToString(), height, count)
                         .WithManifestResourceTextResponse(resourceName)));
 
                     // Execute
-                    var result = await api.GetAccountBlocksByHeight(addr, pageIndex, pageSize);
+                    var result = await api.GetAccountBlocksByHeight(addr, height, count);
 
                     // Validate
                     result.Should().NotBeNull();
@@ -2339,7 +2339,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, 10)]
-                public async Task EmptyResponseAsync(string address, int pageIndex, int pageSize)
+                public async Task EmptyResponseAsync(string address, uint pageIndex, uint pageSize)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2359,7 +2359,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData("z1qqwttth8sj5fchuqyr0ctum63hax2rqfyswk8y", 0, 10,
                     "Zenon.Resources.api.ledger.getAccountBlocksByPage.json")]
-                public async Task ListResponseAsync(string address, int pageIndex, int pageSize, string resourceName)
+                public async Task ListResponseAsync(string address, uint pageIndex, uint pageSize, string resourceName)
                 {
                     // Setup
                     var addr = Address.Parse(address);
@@ -2500,7 +2500,7 @@ namespace Zenon.Api
 
                 [Theory]
                 [InlineData(140, 10)]
-                public async Task EmptyResponseAsync(long height, long count)
+                public async Task EmptyResponseAsync(ulong height, ulong count)
                 {
                     // Setup
                     var api = new LedgerApi(new Lazy<IClient>(() => new TestClient()
@@ -2519,7 +2519,7 @@ namespace Zenon.Api
                 [Theory]
                 [InlineData(140, 10,
                     "Zenon.Resources.api.ledger.getMomentumsByHeight.json")]
-                public async Task ListResponseAsync(long height, long count, string resourceName)
+                public async Task ListResponseAsync(ulong height, ulong count, string resourceName)
                 {
                     // Setup
                     var api = new LedgerApi(new Lazy<IClient>(() => new TestClient()

--- a/src/Zenon/Api/Embedded/AcceleratorApi.cs
+++ b/src/Zenon/Api/Embedded/AcceleratorApi.cs
@@ -21,7 +21,7 @@ namespace Zenon.Api.Embedded
 
         public Lazy<IClient> Client { get; }
 
-        public async Task<ProjectList> GetAll(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<ProjectList> GetAll(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JProjectList>("embedded.accelerator.getAll", pageIndex, pageSize);
             return new ProjectList(response);

--- a/src/Zenon/Api/Embedded/BridgeApi.cs
+++ b/src/Zenon/Api/Embedded/BridgeApi.cs
@@ -43,7 +43,7 @@ namespace Zenon.Api.Embedded
             return new SecurityInfo(response);
         }
 
-        public async Task<BridgeNetworkInfo> GetNetworkInfo(int networkClass, int chainId)
+        public async Task<BridgeNetworkInfo> GetNetworkInfo(uint networkClass, uint chainId)
         {
             var response = await Client.Value.SendRequest<JBridgeNetworkInfo>("embedded.bridge.getNetworkInfo", networkClass, chainId);
             return new BridgeNetworkInfo(response);
@@ -55,49 +55,49 @@ namespace Zenon.Api.Embedded
             return new WrapTokenRequest(response);
         }
 
-        public async Task<WrapTokenRequestList> GetAllWrapTokenRequests(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<WrapTokenRequestList> GetAllWrapTokenRequests(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JWrapTokenRequestList>("embedded.bridge.getAllWrapTokenRequests", pageIndex, pageSize);
             return new WrapTokenRequestList(response);
         }
 
-        public async Task<WrapTokenRequestList> GetAllWrapTokenRequestsByToAddress(string toAddress, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<WrapTokenRequestList> GetAllWrapTokenRequestsByToAddress(string toAddress, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JWrapTokenRequestList>("embedded.bridge.getAllWrapTokenRequestsByToAddress", toAddress, pageIndex, pageSize);
             return new WrapTokenRequestList(response);
         }
 
-        public async Task<WrapTokenRequestList> GetAllWrapTokenRequestsByToAddressNetworkClassAndChainId(string toAddress, int networkClass, int chainId, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<WrapTokenRequestList> GetAllWrapTokenRequestsByToAddressNetworkClassAndChainId(string toAddress, uint networkClass, uint chainId, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JWrapTokenRequestList>("embedded.bridge.getAllWrapTokenRequestsByToAddressNetworkClassAndChainId", toAddress, networkClass, chainId, pageIndex, pageSize);
             return new WrapTokenRequestList(response);
         }
 
-        public async Task<BridgeNetworkInfoList> GetAllNetworks(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<BridgeNetworkInfoList> GetAllNetworks(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JBridgeNetworkInfoList>("embedded.bridge.getAllNetworks", pageIndex, pageSize);
             return new BridgeNetworkInfoList(response);
         }
 
-        public async Task<WrapTokenRequestList> GetAllUnsignedWrapTokenRequests(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<WrapTokenRequestList> GetAllUnsignedWrapTokenRequests(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JWrapTokenRequestList>("embedded.bridge.getAllUnsignedWrapTokenRequests", pageIndex, pageSize);
             return new WrapTokenRequestList(response);
         }
 
-        public async Task<UnwrapTokenRequest> GetUnwrapTokenRequestByHashAndLog(Hash hash, int logIndex)
+        public async Task<UnwrapTokenRequest> GetUnwrapTokenRequestByHashAndLog(Hash hash, uint logIndex)
         {
             var response = await Client.Value.SendRequest<JUnwrapTokenRequest>("embedded.bridge.getUnwrapTokenRequestByHashAndLog", hash.ToString(), logIndex);
             return new UnwrapTokenRequest(response);
         }
 
-        public async Task<UnwrapTokenRequestList> GetAllUnwrapTokenRequests(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<UnwrapTokenRequestList> GetAllUnwrapTokenRequests(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JUnwrapTokenRequestList>("embedded.bridge.getAllUnwrapTokenRequests", pageIndex, pageSize);
             return new UnwrapTokenRequestList(response);
         }
 
-        public async Task<UnwrapTokenRequestList> GetAllUnwrapTokenRequestsByToAddress(string toAddress, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<UnwrapTokenRequestList> GetAllUnwrapTokenRequestsByToAddress(string toAddress, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JUnwrapTokenRequestList>("embedded.bridge.getAllUnwrapTokenRequestsByToAddress", toAddress, pageIndex, pageSize);
             return new UnwrapTokenRequestList(response);
@@ -111,7 +111,7 @@ namespace Zenon.Api.Embedded
 
         // Contract methods
 
-        public AccountBlockTemplate WrapToken(int networkClass, int chainId, string toAddress, BigInteger amount, TokenStandard tokenStandard)
+        public AccountBlockTemplate WrapToken(uint networkClass, uint chainId, string toAddress, BigInteger amount, TokenStandard tokenStandard)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, tokenStandard, amount,
                 Definitions.Bridge.EncodeFunction(nameof(WrapToken),
@@ -125,7 +125,7 @@ namespace Zenon.Api.Embedded
                     id, signature));
         }
 
-        public AccountBlockTemplate UnwrapToken(int networkClass, int chainId, string tokenAddress, Hash txHash, int logIndex, BigInteger amount, Address toAddress, string signature)
+        public AccountBlockTemplate UnwrapToken(uint networkClass, uint chainId, string tokenAddress, Hash txHash, uint logIndex, BigInteger amount, Address toAddress, string signature)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(UnwrapToken),
@@ -139,7 +139,7 @@ namespace Zenon.Api.Embedded
                     signature));
         }
 
-        public AccountBlockTemplate Redeem(Hash hash, int logIndex)
+        public AccountBlockTemplate Redeem(Hash hash, uint logIndex)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(Redeem),
@@ -183,7 +183,7 @@ namespace Zenon.Api.Embedded
                     administrator));
         }
 
-        public AccountBlockTemplate SetNetwork(int networkClass, int chainId, string name, string contractAddress, string metadata)
+        public AccountBlockTemplate SetNetwork(uint networkClass, uint chainId, string name, string contractAddress, string metadata)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(SetNetwork),
@@ -194,7 +194,7 @@ namespace Zenon.Api.Embedded
                     metadata));
         }
 
-        public AccountBlockTemplate RemoveNetwork(int networkClass, int chainId)
+        public AccountBlockTemplate RemoveNetwork(uint networkClass, uint chainId)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(RemoveNetwork),
@@ -202,7 +202,7 @@ namespace Zenon.Api.Embedded
                     chainId));
         }
 
-        public AccountBlockTemplate SetTokenPair(int networkClass, int chainId, TokenStandard tokenStandard, string tokenAddress, bool bridgeable, bool redeemable, bool owned, BigInteger minAmount, BigInteger fee, int redeemDelay, string metadata)
+        public AccountBlockTemplate SetTokenPair(uint networkClass, uint chainId, TokenStandard tokenStandard, string tokenAddress, bool bridgeable, bool redeemable, bool owned, BigInteger minAmount, BigInteger fee, ulong redeemDelay, string metadata)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(SetTokenPair),
@@ -219,7 +219,7 @@ namespace Zenon.Api.Embedded
                     metadata));
         }
 
-        public AccountBlockTemplate RemoveTokenPair(int networkClass, int chainId, TokenStandard tokenStandard, string tokenAddress)
+        public AccountBlockTemplate RemoveTokenPair(uint networkClass, uint chainId, TokenStandard tokenStandard, string tokenAddress)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(RemoveTokenPair),
@@ -229,7 +229,7 @@ namespace Zenon.Api.Embedded
                     tokenAddress));
         }
 
-        public AccountBlockTemplate SetNetworkMetadata(int networkClass, int chainId, string metadata)
+        public AccountBlockTemplate SetNetworkMetadata(uint networkClass, uint chainId, string metadata)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(SetNetworkMetadata),
@@ -238,7 +238,7 @@ namespace Zenon.Api.Embedded
                     metadata));
         }
 
-        public AccountBlockTemplate SetOrchestratorInfo(long windowSize, int keyGenThreshold, int confirmationsToFinality, int estimatedMomentumTime)
+        public AccountBlockTemplate SetOrchestratorInfo(ulong windowSize, uint keyGenThreshold, uint confirmationsToFinality, uint estimatedMomentumTime)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(SetOrchestratorInfo),
@@ -275,14 +275,14 @@ namespace Zenon.Api.Embedded
                 Definitions.Bridge.EncodeFunction(nameof(Emergency)));
         }
 
-        public AccountBlockTemplate SetRedeemDelay(long redeemDelay)
+        public AccountBlockTemplate SetRedeemDelay(ulong redeemDelay)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(SetRedeemDelay),
                     redeemDelay));
         }
 
-        public AccountBlockTemplate RevokeUnwrapRequest(Hash transactionHash, int logIndex)
+        public AccountBlockTemplate RevokeUnwrapRequest(Hash transactionHash, uint logIndex)
         {
             return AccountBlockTemplate.CallContract(Address.BridgeAddress, TokenStandard.ZnnZts, BigInteger.Zero,
                 Definitions.Bridge.EncodeFunction(nameof(RevokeUnwrapRequest),

--- a/src/Zenon/Api/Embedded/LiquidityApi.cs
+++ b/src/Zenon/Api/Embedded/LiquidityApi.cs
@@ -25,7 +25,7 @@ namespace Zenon.Api.Embedded
             return new UncollectedReward(response);
         }
 
-        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JRewardHistoryList>("embedded.liquidity.getFrontierRewardByPage", address.ToString(), pageIndex, pageSize);
             return new RewardHistoryList(response);
@@ -43,7 +43,7 @@ namespace Zenon.Api.Embedded
             return new SecurityInfo(response);
         }
 
-        public async Task<LiquidityStakeList> GetLiquidityStakeEntriesByAddress(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<LiquidityStakeList> GetLiquidityStakeEntriesByAddress(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JLiquidityStakeList>("embedded.liquidity.getLiquidityStakeEntriesByAddress", address.ToString(), pageIndex, pageSize);
             return new LiquidityStakeList(response);

--- a/src/Zenon/Api/Embedded/PillarApi.cs
+++ b/src/Zenon/Api/Embedded/PillarApi.cs
@@ -33,7 +33,7 @@ namespace Zenon.Api.Embedded
             return new UncollectedReward(response);
         }
 
-        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JRewardHistoryList>("embedded.pillar.getFrontierRewardByPage", address.ToString(), pageIndex, pageSize);
             return new RewardHistoryList(response);
@@ -45,7 +45,7 @@ namespace Zenon.Api.Embedded
                 Client.Value.SendRequest<string>("embedded.pillar.getQsrRegistrationCost"));
         }
 
-        public async Task<PillarInfoList> GetAll(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<PillarInfoList> GetAll(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JPillarInfoList>("embedded.pillar.getAll", pageIndex, pageSize);
             return new PillarInfoList(response);
@@ -74,13 +74,13 @@ namespace Zenon.Api.Embedded
             return response != null ? new DelegationInfo(response) : null;
         }
 
-        public async Task<PillarEpochHistoryList> GetPillarEpochHistory(string name, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<PillarEpochHistoryList> GetPillarEpochHistory(string name, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JPillarEpochHistoryList>("embedded.pillar.getPillarEpochHistory", name, pageIndex, pageSize);
             return new PillarEpochHistoryList(response);
         }
 
-        public async Task<PillarEpochHistoryList> GetPillarsHistoryByEpoch(int epoch, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<PillarEpochHistoryList> GetPillarsHistoryByEpoch(ulong epoch, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JPillarEpochHistoryList>("embedded.pillar.getPillarsHistoryByEpoch", epoch, pageIndex, pageSize);
             return new PillarEpochHistoryList(response);

--- a/src/Zenon/Api/Embedded/PlasmaApi.cs
+++ b/src/Zenon/Api/Embedded/PlasmaApi.cs
@@ -25,7 +25,7 @@ namespace Zenon.Api.Embedded
             return new PlasmaInfo(response);
         }
 
-        public async Task<FusionEntryList> GetEntriesByAddress(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<FusionEntryList> GetEntriesByAddress(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JFusionEntryList>("embedded.plasma.getEntriesByAddress", address.ToString(), pageIndex, pageSize);
             return new FusionEntryList(response);

--- a/src/Zenon/Api/Embedded/SentinelApi.cs
+++ b/src/Zenon/Api/Embedded/SentinelApi.cs
@@ -20,7 +20,7 @@ namespace Zenon.Api.Embedded
 
         public Lazy<IClient> Client { get; }
 
-        public async Task<SentinelInfoList> GetAllActive(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<SentinelInfoList> GetAllActive(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JSentinelInfoList>("embedded.sentinel.getAllActive", pageIndex, pageSize);
             return new SentinelInfoList(response);
@@ -44,7 +44,7 @@ namespace Zenon.Api.Embedded
             return new UncollectedReward(response);
         }
 
-        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JRewardHistoryList>("embedded.sentinel.getFrontierRewardByPage", address.ToString(), pageIndex, pageSize);
             return new RewardHistoryList(response);

--- a/src/Zenon/Api/Embedded/SporkApi.cs
+++ b/src/Zenon/Api/Embedded/SporkApi.cs
@@ -18,7 +18,7 @@ namespace Zenon.Api.Embedded
 
         public Lazy<IClient> Client { get; }
 
-        public async Task<SporkList> GetAll(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<SporkList> GetAll(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JSporkList>("embedded.spork.getAll", pageIndex, pageSize);
             return new SporkList(response);

--- a/src/Zenon/Api/Embedded/StakeApi.cs
+++ b/src/Zenon/Api/Embedded/StakeApi.cs
@@ -19,7 +19,7 @@ namespace Zenon.Api.Embedded
 
         public Lazy<IClient> Client { get; }
 
-        public async Task<StakeList> GetEntriesByAddress(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<StakeList> GetEntriesByAddress(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JStakeList>("embedded.stake.getEntriesByAddress", address.ToString(), pageIndex, pageSize);
             return new StakeList(response);
@@ -31,7 +31,7 @@ namespace Zenon.Api.Embedded
             return new UncollectedReward(response);
         }
 
-        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<RewardHistoryList> GetFrontierRewardByPage(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JRewardHistoryList>("embedded.stake.getFrontierRewardByPage", address.ToString(), pageIndex, pageSize);
             return new RewardHistoryList(response);

--- a/src/Zenon/Api/Embedded/TokenApi.cs
+++ b/src/Zenon/Api/Embedded/TokenApi.cs
@@ -18,13 +18,13 @@ namespace Zenon.Api.Embedded
 
         public Lazy<IClient> Client { get; }
 
-        public async Task<TokenList> GetAll(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<TokenList> GetAll(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JTokenList>("embedded.token.getAll", pageIndex, pageSize);
             return new TokenList(response);
         }
 
-        public async Task<TokenList> GetByOwner(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<TokenList> GetByOwner(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JTokenList>("embedded.token.getByOwner", address.ToString(), pageIndex, pageSize);
             return new TokenList(response);
@@ -38,7 +38,7 @@ namespace Zenon.Api.Embedded
 
         // Contract methods
         public AccountBlockTemplate IssueToken(string tokenName, string tokenSymbol, string tokenDomain,
-            long totalSupply, long maxSupply, int decimals,
+            BigInteger totalSupply, BigInteger maxSupply, int decimals,
             bool mintable, bool burnable, bool utility)
         {
             return AccountBlockTemplate.CallContract(Address.TokenAddress, TokenStandard.ZnnZts, Constants.TokenZtsIssueFeeInZnn,

--- a/src/Zenon/Api/LedgerApi.cs
+++ b/src/Zenon/Api/LedgerApi.cs
@@ -22,13 +22,13 @@ namespace Zenon.Api
             await Client.Value.SendRequest("ledger.publishRawTransaction", accountBlockTemplate.ToJson());
         }
 
-        public async Task<AccountBlockList> GetUnconfirmedBlocksByAddress(Address address, int pageIndex = 0, int pageSize = Constants.MemoryPoolPageSize)
+        public async Task<AccountBlockList> GetUnconfirmedBlocksByAddress(Address address, uint pageIndex = 0, uint pageSize = Constants.MemoryPoolPageSize)
         {
             var response = await Client.Value.SendRequest<JAccountBlockList>("ledger.getUnconfirmedBlocksByAddress", address.ToString(), pageIndex, pageSize);
             return new AccountBlockList(response);
         }
 
-        public async Task<AccountBlockList> GetUnreceivedBlocksByAddress(Address address, int pageIndex = 0, int pageSize = Constants.MemoryPoolPageSize)
+        public async Task<AccountBlockList> GetUnreceivedBlocksByAddress(Address address, uint pageIndex = 0, uint pageSize = Constants.MemoryPoolPageSize)
         {
             var response = await Client.Value.SendRequest<JAccountBlockList>("ledger.getUnreceivedBlocksByAddress", address.ToString(), pageIndex, pageSize);
             return new AccountBlockList(response);
@@ -47,14 +47,14 @@ namespace Zenon.Api
             return response != null ? new AccountBlock(response) : null;
         }
 
-        public async Task<AccountBlockList> GetAccountBlocksByHeight(Address address, int height = 1, int count = Constants.RpcMaxPageSize)
+        public async Task<AccountBlockList> GetAccountBlocksByHeight(Address address, ulong height = 1, ulong count = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JAccountBlockList>("ledger.getAccountBlocksByHeight", address.ToString(), height, count);
             return new AccountBlockList(response);
         }
 
         /// pageIndex = 0 returns the most recent account blocks sorted descending by height
-        public async Task<AccountBlockList> GetAccountBlocksByPage(Address address, int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<AccountBlockList> GetAccountBlocksByPage(Address address, uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JAccountBlockList>("ledger.getAccountBlocksByPage", address.ToString(), pageIndex, pageSize);
             return new AccountBlockList(response);
@@ -79,7 +79,7 @@ namespace Zenon.Api
             return response != null ? new Momentum(response) : null;
         }
 
-        public async Task<MomentumList> GetMomentumsByHeight(long height, long count)
+        public async Task<MomentumList> GetMomentumsByHeight(ulong height, ulong count)
         {
             height = height < 1 ? 1 : height;
             count = count > Constants.RpcMaxPageSize ? Constants.RpcMaxPageSize : count;
@@ -88,13 +88,13 @@ namespace Zenon.Api
         }
 
         /// pageIndex = 0 returns the most recent momentums sorted descending by height
-        public async Task<MomentumList> GetMomentumsByPage(int pageIndex = 0, int pageSize = Constants.RpcMaxPageSize)
+        public async Task<MomentumList> GetMomentumsByPage(uint pageIndex = 0, uint pageSize = Constants.RpcMaxPageSize)
         {
             var response = await Client.Value.SendRequest<JMomentumList>("ledger.getMomentumsByPage", pageIndex, pageSize);
             return new MomentumList(response);
         }
 
-        public async Task<DetailedMomentumList> GetDetailedMomentumsByHeight(long height, long count)
+        public async Task<DetailedMomentumList> GetDetailedMomentumsByHeight(ulong height, ulong count)
         {
             height = height < 1 ? 1 : height;
             count = count > Constants.RpcMaxPageSize ? Constants.RpcMaxPageSize : count;

--- a/src/Zenon/Model/Embedded/BridgeInfo.cs
+++ b/src/Zenon/Model/Embedded/BridgeInfo.cs
@@ -23,9 +23,9 @@ namespace Zenon.Model.Embedded
         public string DecompressedTssECDSAPubKey { get; }
         public bool AllowKeyGen { get; }
         public bool Halted { get; }
-        public long UnhaltedAt { get; }
-        public long UnhaltDurationInMomentums { get; }
-        public long TssNonce { get; }
+        public ulong UnhaltedAt { get; }
+        public ulong UnhaltDurationInMomentums { get; }
+        public ulong TssNonce { get; }
         public string Metadata { get; }
 
         public virtual JBridgeInfo ToJson()

--- a/src/Zenon/Model/Embedded/BridgeNetworkInfo.cs
+++ b/src/Zenon/Model/Embedded/BridgeNetworkInfo.cs
@@ -17,8 +17,8 @@ namespace Zenon.Model.Embedded
                 : new TokenPair[0];
         }
 
-        public int NetworkClass { get; }
-        public int ChainId { get; }
+        public uint NetworkClass { get; }
+        public uint ChainId { get; }
         public string Name { get; }
         public string ContractAddress { get; }
         public string Metadata { get; }

--- a/src/Zenon/Model/Embedded/BridgeNetworkInfoList.cs
+++ b/src/Zenon/Model/Embedded/BridgeNetworkInfoList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new BridgeNetworkInfo[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public BridgeNetworkInfo[] List { get; }
 
         public virtual JBridgeNetworkInfoList ToJson()

--- a/src/Zenon/Model/Embedded/FusionEntry.cs
+++ b/src/Zenon/Model/Embedded/FusionEntry.cs
@@ -15,7 +15,7 @@ namespace Zenon.Model.Embedded
             Id = Hash.Parse(json.id);
         }
 
-        public FusionEntry(Address beneficiary, long expirationHeight, Hash id, BigInteger qsrAmount)
+        public FusionEntry(Address beneficiary, ulong expirationHeight, Hash id, BigInteger qsrAmount)
         {
             Beneficiary = beneficiary;
             ExpirationHeight = expirationHeight;
@@ -25,7 +25,7 @@ namespace Zenon.Model.Embedded
 
         public BigInteger QsrAmount { get; }
         public Address Beneficiary { get; }
-        public long ExpirationHeight { get; }
+        public ulong ExpirationHeight { get; }
         public Hash Id { get; }
         public bool? IsRevocable { get; }
 

--- a/src/Zenon/Model/Embedded/FusionEntryList.cs
+++ b/src/Zenon/Model/Embedded/FusionEntryList.cs
@@ -16,7 +16,7 @@ namespace Zenon.Model.Embedded
                 : new FusionEntry[0];
         }
 
-        public FusionEntryList(BigInteger qsrAmount, long count, FusionEntry[] list)
+        public FusionEntryList(BigInteger qsrAmount, ulong count, FusionEntry[] list)
         {
             QsrAmount = qsrAmount;
             Count = count;
@@ -24,7 +24,7 @@ namespace Zenon.Model.Embedded
         }
 
         public BigInteger QsrAmount { get; }
-        public long Count { get; }
+        public ulong Count { get; }
         public FusionEntry[] List { get; }
 
         public virtual JFusionEntryList ToJson()

--- a/src/Zenon/Model/Embedded/Json/JBridgeInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JBridgeInfo.cs
@@ -7,9 +7,9 @@
         public string decompressedTssECDSAPubKey { get; set; }
         public bool allowKeyGen { get; set; }
         public bool halted { get; set; }
-        public long unhaltedAt { get; set; }
-        public long unhaltDurationInMomentums { get; set; }
-        public long tssNonce { get; set; }
+        public ulong unhaltedAt { get; set; }
+        public ulong unhaltDurationInMomentums { get; set; }
+        public ulong tssNonce { get; set; }
         public string metadata { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JBridgeNetworkInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JBridgeNetworkInfo.cs
@@ -2,8 +2,8 @@
 {
     public class JBridgeNetworkInfo
     {
-        public int networkClass { get; set; }
-        public int chainId { get; set; }
+        public uint networkClass { get; set; }
+        public uint chainId { get; set; }
         public string name { get; set; }
         public string contractAddress { get; set; }
         public string metadata { get; set; }

--- a/src/Zenon/Model/Embedded/Json/JBridgeNetworkInfoList.cs
+++ b/src/Zenon/Model/Embedded/Json/JBridgeNetworkInfoList.cs
@@ -2,7 +2,7 @@
 {
     public class JBridgeNetworkInfoList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JBridgeNetworkInfo[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JFusionEntry.cs
+++ b/src/Zenon/Model/Embedded/Json/JFusionEntry.cs
@@ -4,7 +4,7 @@
     {
         public string qsrAmount { get; set; }
         public string beneficiary { get; set; }
-        public long expirationHeight { get; set; }
+        public ulong expirationHeight { get; set; }
         public string id { get; set; }
         public bool? isRevocable { get; set; }
     }

--- a/src/Zenon/Model/Embedded/Json/JFusionEntryList.cs
+++ b/src/Zenon/Model/Embedded/Json/JFusionEntryList.cs
@@ -3,7 +3,7 @@
     public class JFusionEntryList
     {
         public string qsrAmount { get; set; }
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JFusionEntry[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JLiquidityStakeList.cs
+++ b/src/Zenon/Model/Embedded/Json/JLiquidityStakeList.cs
@@ -4,7 +4,7 @@
     {
         public string totalAmount { get; set; }
         public string totalWeightedAmount { get; set; }
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JLiquidityStakeEntry[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JOrchestratorInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JOrchestratorInfo.cs
@@ -2,10 +2,10 @@
 {
     public class JOrchestratorInfo
     {
-        public long windowSize { get; set; }
-        public long keyGenThreshold { get; set; }
-        public long confirmationsToFinality { get; set; }
-        public long estimatedMomentumTime { get; set; }
-        public long allowKeyGenHeight { get; set; }
+        public ulong windowSize { get; set; }
+        public uint keyGenThreshold { get; set; }
+        public uint confirmationsToFinality { get; set; }
+        public uint estimatedMomentumTime { get; set; }
+        public ulong allowKeyGenHeight { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JPillarEpochHistory.cs
+++ b/src/Zenon/Model/Embedded/Json/JPillarEpochHistory.cs
@@ -3,11 +3,11 @@
     public class JPillarEpochHistory
     {
         public string name { get; set; }
-        public long epoch { get; set; }
-        public long giveBlockRewardPercentage { get; set; }
-        public long giveDelegateRewardPercentage { get; set; }
-        public long producedBlockNum { get; set; }
-        public long expectedBlockNum { get; set; }
+        public ulong epoch { get; set; }
+        public int giveBlockRewardPercentage { get; set; }
+        public int giveDelegateRewardPercentage { get; set; }
+        public int producedBlockNum { get; set; }
+        public int expectedBlockNum { get; set; }
         public string weight { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JPillarEpochHistoryList.cs
+++ b/src/Zenon/Model/Embedded/Json/JPillarEpochHistoryList.cs
@@ -2,7 +2,7 @@
 {
     public class JPillarEpochHistoryList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JPillarEpochHistory[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JPillarEpochStats.cs
+++ b/src/Zenon/Model/Embedded/Json/JPillarEpochStats.cs
@@ -2,7 +2,7 @@
 {
     public class JPillarEpochStats
     {
-        public long producedMomentums { get; set; }
-        public long expectedMomentums { get; set; }
+        public int producedMomentums { get; set; }
+        public int expectedMomentums { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JPillarInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JPillarInfo.cs
@@ -3,19 +3,19 @@
     public class JPillarInfo
     {
         public string name { get; set; }
-        public long rank { get; set; }
+        public int rank { get; set; }
         public int type { get; set; }
         public string ownerAddress { get; set; }
         public string producerAddress { get; set; }
         public string withdrawAddress { get; set; }
-        public long giveMomentumRewardPercentage { get; set; }
-        public long giveDelegateRewardPercentage { get; set; }
+        public int giveMomentumRewardPercentage { get; set; }
+        public int giveDelegateRewardPercentage { get; set; }
         public bool isRevocable { get; set; }
         public long revokeCooldown { get; set; }
         public long revokeTimestamp { get; set; }
         public JPillarEpochStats currentStats { get; set; }
         public string weight { get; set; }
-        public long producedMomentums { get; set; }
-        public long expectedMomentums { get; set; }
+        public int producedMomentums { get; set; }
+        public int expectedMomentums { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JPillarInfoList.cs
+++ b/src/Zenon/Model/Embedded/Json/JPillarInfoList.cs
@@ -2,7 +2,7 @@
 {
     public class JPillarInfoList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JPillarInfo[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JProjectList.cs
+++ b/src/Zenon/Model/Embedded/Json/JProjectList.cs
@@ -2,7 +2,7 @@
 {
     public class JProjectList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JProject[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JRewardHistoryList.cs
+++ b/src/Zenon/Model/Embedded/Json/JRewardHistoryList.cs
@@ -2,7 +2,7 @@
 {
     public class JRewardHistoryList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JRewardHistoryEntry[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JSecurityInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JSecurityInfo.cs
@@ -4,7 +4,7 @@
     {
         public string[] guardians { get; set; }
         public string[] guardiansVotes { get; set; }
-        public long administratorDelay { get; set; }
-        public long softDelay { get; set; }
+        public ulong administratorDelay { get; set; }
+        public ulong softDelay { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JSentinelInfoList.cs
+++ b/src/Zenon/Model/Embedded/Json/JSentinelInfoList.cs
@@ -2,7 +2,7 @@
 {
     public class JSentinelInfoList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JSentinelInfo[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JSpork.cs
+++ b/src/Zenon/Model/Embedded/Json/JSpork.cs
@@ -6,6 +6,6 @@
         public string name { get; set; }
         public string description { get; set; }
         public bool activated { get; set; }
-        public long enforcementHeight { get; set; }
+        public ulong enforcementHeight { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JSporkList.cs
+++ b/src/Zenon/Model/Embedded/Json/JSporkList.cs
@@ -2,7 +2,7 @@
 {
     public class JSporkList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JSpork[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JStakeList.cs
+++ b/src/Zenon/Model/Embedded/Json/JStakeList.cs
@@ -4,7 +4,7 @@
     {
         public string totalAmount { get; set; }
         public string totalWeightedAmount { get; set; }
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JStakeEntry[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JTimeChallengeInfo.cs
+++ b/src/Zenon/Model/Embedded/Json/JTimeChallengeInfo.cs
@@ -4,6 +4,6 @@
     {
         public string methodName { get; set; }
         public string paramsHash { get; set; }
-        public long challengeStartHeight { get; set; }
+        public ulong challengeStartHeight { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JTimeChallengesList.cs
+++ b/src/Zenon/Model/Embedded/Json/JTimeChallengesList.cs
@@ -2,7 +2,7 @@
 {
     public class JTimeChallengesList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JTimeChallengeInfo[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JTokenPair.cs
+++ b/src/Zenon/Model/Embedded/Json/JTokenPair.cs
@@ -8,8 +8,8 @@
         public bool redeemable { get; set; }
         public bool owned { get; set; }
         public string minAmount { get; set; }
-        public int feePercentage { get; set; }
-        public int redeemDelay { get; set; }
+        public uint feePercentage { get; set; }
+        public ulong redeemDelay { get; set; }
         public string metadata { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JUnwrapTokenRequest.cs
+++ b/src/Zenon/Model/Embedded/Json/JUnwrapTokenRequest.cs
@@ -2,11 +2,11 @@
 {
     public class JUnwrapTokenRequest
     {
-        public long registrationMomentumHeight { get; set; }
-        public int networkClass { get; set; }
+        public ulong registrationMomentumHeight { get; set; }
+        public uint networkClass { get; set; }
         public string transactionHash { get; set; }
-        public long logIndex { get; set; }
-        public int chainId { get; set; }
+        public uint logIndex { get; set; }
+        public uint chainId { get; set; }
         public string toAddress { get; set; }
         public string tokenStandard { get; set; }
         public string tokenAddress { get; set; }

--- a/src/Zenon/Model/Embedded/Json/JUnwrapTokenRequestList.cs
+++ b/src/Zenon/Model/Embedded/Json/JUnwrapTokenRequestList.cs
@@ -2,7 +2,7 @@
 {
     public class JUnwrapTokenRequestList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JUnwrapTokenRequest[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JWrapTokenRequest.cs
+++ b/src/Zenon/Model/Embedded/Json/JWrapTokenRequest.cs
@@ -2,8 +2,8 @@
 {
     public class JWrapTokenRequest
     {
-        public int networkClass { get; set; }
-        public int chainId { get; set; }
+        public uint networkClass { get; set; }
+        public uint chainId { get; set; }
         public string id { get; set; }
         public string toAddress { get; set; }
         public string tokenStandard { get; set; }
@@ -11,6 +11,6 @@
         public string amount { get; set; }
         public string fee { get; set; }
         public string signature { get; set; }
-        public long creationMomentumHeight { get; set; }
+        public ulong creationMomentumHeight { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/Json/JWrapTokenRequestList.cs
+++ b/src/Zenon/Model/Embedded/Json/JWrapTokenRequestList.cs
@@ -2,7 +2,7 @@
 {
     public class JWrapTokenRequestList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JWrapTokenRequest[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/Embedded/LiquidityStakeList.cs
+++ b/src/Zenon/Model/Embedded/LiquidityStakeList.cs
@@ -19,7 +19,7 @@ namespace Zenon.Model.Embedded
 
         public BigInteger TotalAmount { get; }
         public BigInteger TotalWeightedAmount { get; }
-        public long Count { get; }
+        public ulong Count { get; }
         public LiquidityStakeEntry[] List { get; }
 
         public virtual JLiquidityStakeList ToJson()

--- a/src/Zenon/Model/Embedded/OrchestratorInfo.cs
+++ b/src/Zenon/Model/Embedded/OrchestratorInfo.cs
@@ -13,11 +13,11 @@ namespace Zenon.Model.Embedded
             AllowKeyGenHeight = json.allowKeyGenHeight;
         }
 
-        public long WindowSize { get; }
-        public long KeyGenThreshold { get; }
-        public long ConfirmationsToFinality { get; }
-        public long EstimatedMomentumTime { get; }
-        public long AllowKeyGenHeight { get; }
+        public ulong WindowSize { get; }
+        public uint KeyGenThreshold { get; }
+        public uint ConfirmationsToFinality { get; }
+        public uint EstimatedMomentumTime { get; }
+        public ulong AllowKeyGenHeight { get; }
 
         public virtual JOrchestratorInfo ToJson()
         {

--- a/src/Zenon/Model/Embedded/PillarEpochHistory.cs
+++ b/src/Zenon/Model/Embedded/PillarEpochHistory.cs
@@ -19,12 +19,12 @@ namespace Zenon.Model.Embedded
 
         public PillarEpochHistory(
             string name,
-            long epoch,
-            long giveBlockRewardPercentage,
-            long giveDelegateRewardPercentage,
-            long producedBlockNum,
-            long expectedBlockNum,
-            long weight)
+            ulong epoch,
+            int giveBlockRewardPercentage,
+            int giveDelegateRewardPercentage,
+            int producedBlockNum,
+            int expectedBlockNum,
+            BigInteger weight)
         {
             Name = name;
             Epoch = epoch;
@@ -36,11 +36,11 @@ namespace Zenon.Model.Embedded
         }
 
         public string Name { get; }
-        public long Epoch { get; }
-        public long GiveBlockRewardPercentage { get; }
-        public long GiveDelegateRewardPercentage { get; }
-        public long ProducedBlockNum { get; }
-        public long ExpectedBlockNum { get; }
+        public ulong Epoch { get; }
+        public int GiveBlockRewardPercentage { get; }
+        public int GiveDelegateRewardPercentage { get; }
+        public int ProducedBlockNum { get; }
+        public int ExpectedBlockNum { get; }
         public BigInteger Weight { get; }
 
         public virtual JPillarEpochHistory ToJson()

--- a/src/Zenon/Model/Embedded/PillarEpochHistoryList.cs
+++ b/src/Zenon/Model/Embedded/PillarEpochHistoryList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new PillarEpochHistory[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public PillarEpochHistory[] List { get; }
 
         public virtual JPillarEpochHistoryList ToJson()

--- a/src/Zenon/Model/Embedded/PillarEpochStats.cs
+++ b/src/Zenon/Model/Embedded/PillarEpochStats.cs
@@ -10,8 +10,8 @@ namespace Zenon.Model.Embedded
             ExpectedMomentums = json.expectedMomentums;
         }
 
-        public long ProducedMomentums { get; }
-        public long ExpectedMomentums { get; }
+        public int ProducedMomentums { get; }
+        public int ExpectedMomentums { get; }
 
         public virtual JPillarEpochStats ToJson()
         {

--- a/src/Zenon/Model/Embedded/PillarInfo.cs
+++ b/src/Zenon/Model/Embedded/PillarInfo.cs
@@ -31,7 +31,7 @@ namespace Zenon.Model.Embedded
         }
 
         public string Name { get; }
-        public long Rank { get; }
+        public int Rank { get; }
         public int Type { get; }
         public Address OwnerAddress { get; }
         public Address ProducerAddress { get; }
@@ -43,8 +43,8 @@ namespace Zenon.Model.Embedded
         public long RevokeTimestamp { get; }
         public PillarEpochStats CurrentStats { get; }
         public BigInteger Weight { get; }
-        public long ProducedMomentums { get; }
-        public long ExpectedMomentums { get; }
+        public int ProducedMomentums { get; }
+        public int ExpectedMomentums { get; }
 
         public virtual JPillarInfo ToJson()
         {

--- a/src/Zenon/Model/Embedded/PillarInfoList.cs
+++ b/src/Zenon/Model/Embedded/PillarInfoList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new PillarInfo[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public PillarInfo[] List { get; }
 
         public virtual JPillarInfoList ToJson()

--- a/src/Zenon/Model/Embedded/ProjectList.cs
+++ b/src/Zenon/Model/Embedded/ProjectList.cs
@@ -6,7 +6,7 @@ namespace Zenon.Model.Embedded
 {
     public class ProjectList : IJsonConvertible<JProjectList>
     {
-        public long Count { get; }
+        public ulong Count { get; }
         public Project[] List { get; }
 
         public ProjectList(JProjectList json)

--- a/src/Zenon/Model/Embedded/RewardHistoryList.cs
+++ b/src/Zenon/Model/Embedded/RewardHistoryList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new RewardHistoryEntry[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public RewardHistoryEntry[] List { get; }
 
         public virtual JRewardHistoryList ToJson()

--- a/src/Zenon/Model/Embedded/SecurityInfo.cs
+++ b/src/Zenon/Model/Embedded/SecurityInfo.cs
@@ -16,8 +16,8 @@ namespace Zenon.Model.Embedded
 
         public Address[] Guardians { get; }
         public Address[] GuardiansVotes { get; }
-        public long AdministratorDelay { get; }
-        public long SoftDelay { get; }
+        public ulong AdministratorDelay { get; }
+        public ulong SoftDelay { get; }
 
         public virtual JSecurityInfo ToJson()
         {

--- a/src/Zenon/Model/Embedded/SentinelList.cs
+++ b/src/Zenon/Model/Embedded/SentinelList.cs
@@ -13,13 +13,13 @@ namespace Zenon.Model.Embedded
                 : new SentinelInfo[0];
         }
 
-        public SentinelInfoList(long count, SentinelInfo[] list)
+        public SentinelInfoList(ulong count, SentinelInfo[] list)
         {
             Count = count;
             List = list;
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public SentinelInfo[] List { get; }
 
         public virtual JSentinelInfoList ToJson()

--- a/src/Zenon/Model/Embedded/Spork.cs
+++ b/src/Zenon/Model/Embedded/Spork.cs
@@ -18,7 +18,7 @@ namespace Zenon.Model.Embedded
         public string Name { get; }
         public string Description { get; }
         public bool Activated { get; }
-        public long EnforcementHeight { get; }
+        public ulong EnforcementHeight { get; }
 
         public virtual JSpork ToJson()
         {

--- a/src/Zenon/Model/Embedded/SporkList.cs
+++ b/src/Zenon/Model/Embedded/SporkList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new Spork[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public Spork[] List { get; }
 
         public virtual JSporkList ToJson()

--- a/src/Zenon/Model/Embedded/StakeList.cs
+++ b/src/Zenon/Model/Embedded/StakeList.cs
@@ -17,7 +17,7 @@ namespace Zenon.Model.Embedded
                 : new StakeEntry[0];
         }
 
-        public StakeList(BigInteger totalAmount, BigInteger totalWeightedAmount, long count, StakeEntry[] list)
+        public StakeList(BigInteger totalAmount, BigInteger totalWeightedAmount, ulong count, StakeEntry[] list)
         {
             TotalAmount = totalAmount;
             TotalWeightedAmount = totalWeightedAmount;
@@ -27,7 +27,7 @@ namespace Zenon.Model.Embedded
 
         public BigInteger TotalAmount { get; }
         public BigInteger TotalWeightedAmount { get; }
-        public long Count { get; }
+        public ulong Count { get; }
         public StakeEntry[] List { get; }
 
         public virtual JStakeList ToJson()

--- a/src/Zenon/Model/Embedded/TimeChallengeInfo.cs
+++ b/src/Zenon/Model/Embedded/TimeChallengeInfo.cs
@@ -14,7 +14,7 @@ namespace Zenon.Model.Embedded
 
         public string MethodName { get; set; }
         public Hash ParamsHash { get; set; }
-        public long ChallengeStartHeight { get; set; }
+        public ulong ChallengeStartHeight { get; set; }
 
         public virtual JTimeChallengeInfo ToJson()
         {

--- a/src/Zenon/Model/Embedded/TimeChallengesList.cs
+++ b/src/Zenon/Model/Embedded/TimeChallengesList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new TimeChallengeInfo[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public TimeChallengeInfo[] List { get; }
 
         public virtual JTimeChallengesList ToJson()

--- a/src/Zenon/Model/Embedded/TokenPair.cs
+++ b/src/Zenon/Model/Embedded/TokenPair.cs
@@ -26,8 +26,8 @@ namespace Zenon.Model.Embedded
         public bool Redeemable { get; }
         public bool Owned { get; }
         public BigInteger MinAmount { get; }
-        public int FeePercentage { get; }
-        public int RedeemDelay { get; }
+        public uint FeePercentage { get; }
+        public ulong RedeemDelay { get; }
         public string Metadata { get; }
 
         public virtual JTokenPair ToJson()

--- a/src/Zenon/Model/Embedded/UnwrapTokenRequest.cs
+++ b/src/Zenon/Model/Embedded/UnwrapTokenRequest.cs
@@ -23,11 +23,11 @@ namespace Zenon.Model.Embedded
             Revoked = json.revoked;
         }
 
-        public long RegistrationMomentumHeight { get; }
-        public int NetworkClass { get; }
-        public int ChainId { get; }
+        public ulong RegistrationMomentumHeight { get; }
+        public uint NetworkClass { get; }
+        public uint ChainId { get; }
         public Hash TransactionHash { get; }
-        public long LogIndex { get; }
+        public uint LogIndex { get; }
         public Address ToAddress { get; }
         public TokenStandard TokenStandard { get; }
         public string TokenAddress { get; }

--- a/src/Zenon/Model/Embedded/UnwrapTokenRequestList.cs
+++ b/src/Zenon/Model/Embedded/UnwrapTokenRequestList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new UnwrapTokenRequest[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public UnwrapTokenRequest[] List { get; }
 
         public virtual JUnwrapTokenRequestList ToJson()

--- a/src/Zenon/Model/Embedded/WrapTokenRequest.cs
+++ b/src/Zenon/Model/Embedded/WrapTokenRequest.cs
@@ -21,8 +21,8 @@ namespace Zenon.Model.Embedded
             CreationMomentumHeight = json.creationMomentumHeight;
         }
 
-        public int NetworkClass { get; }
-        public int ChainId { get; }
+        public uint NetworkClass { get; }
+        public uint ChainId { get; }
         public Hash Id { get; }
         public string ToAddress { get; }
         public TokenStandard TokenStandard { get; }
@@ -30,7 +30,7 @@ namespace Zenon.Model.Embedded
         public BigInteger Amount { get; }
         public BigInteger Fee { get; }
         public string Signature { get; }
-        public long CreationMomentumHeight { get; }
+        public ulong CreationMomentumHeight { get; }
 
         public virtual JWrapTokenRequest ToJson()
         {

--- a/src/Zenon/Model/Embedded/WrapTokenRequestList.cs
+++ b/src/Zenon/Model/Embedded/WrapTokenRequestList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Embedded
                 : new WrapTokenRequest[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public WrapTokenRequest[] List { get; }
 
         public virtual JWrapTokenRequestList ToJson()

--- a/src/Zenon/Model/Json/Stats.cs
+++ b/src/Zenon/Model/Json/Stats.cs
@@ -27,8 +27,8 @@
         public string platformFamily { get; set; }
         public string platformVersion { get; set; }
         public string kernelVersion { get; set; }
-        public long memoryTotal { get; set; }
-        public long memoryFree { get; set; }
+        public ulong memoryTotal { get; set; }
+        public ulong memoryFree { get; set; }
         public long numCPU { get; set; }
         public long numGoroutine { get; set; }
     }
@@ -36,7 +36,7 @@
     public class JSyncInfo
     {
         public long state { get; set; }
-        public long currentHeight { get; set; }
-        public long targetHeight { get; set; }
+        public ulong currentHeight { get; set; }
+        public ulong targetHeight { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/DetailedMomentumList.cs
+++ b/src/Zenon/Model/NoM/DetailedMomentumList.cs
@@ -7,11 +7,11 @@ namespace Zenon.Model.NoM
     {
         public DetailedMomentumList(JDetailedMomentumList json)
         {
-            Count = json.count;
+            Count = json.count.HasValue ? json.count.Value : 0;
             List = json.list != null ? json.list.Select(x => new DetailedMomentum(x)).ToArray() : null;
         }
 
-        public long? Count { get; }
+        public ulong Count { get; }
         public DetailedMomentum[] List { get; }
 
         public virtual JDetailedMomentumList ToJson()

--- a/src/Zenon/Model/NoM/Json/JDetailedMomentumList.cs
+++ b/src/Zenon/Model/NoM/Json/JDetailedMomentumList.cs
@@ -3,6 +3,6 @@
     public class JDetailedMomentumList
     {
         public JDetailedMomentum[] list { get; set; }
-        public long? count { get; set; }
+        public ulong? count { get; set; }
     }
 }


### PR DESCRIPTION
Not all data type definitions were equal and could cause possible overflows. See #9.

All definitions have been checked and aligned with the go-zenon definitions.