### PR TITLE
Sync datatype definitions

### DIFF
--- a/src/Zenon.Tests/Model/Primitives/HashHeightTest.cs
+++ b/src/Zenon.Tests/Model/Primitives/HashHeightTest.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.Primitives
         public void When_GetBytes_ExpectToEqual(string hashString, long? height, string byteString)
         {
             // Setup
-            var hh = new HashHeight(Hash.Parse(hashString), height);
+            var hh = new HashHeight(Hash.Parse(hashString), (ulong?)height);
 
             // Execute
             var bytes = hh.GetBytes();
@@ -28,7 +28,7 @@ namespace Zenon.Model.Primitives
         public void When_Serialize_ExpectToEqual(string hashString, long? height, string expectedJson)
         {
             // Setup
-            var hh = new HashHeight(Hash.Parse(hashString), height);
+            var hh = new HashHeight(Hash.Parse(hashString), (ulong?)height);
 
             // Execute
             string json = JsonConvert.SerializeObject(hh.ToJson(), Formatting.None);
@@ -43,7 +43,7 @@ namespace Zenon.Model.Primitives
         public void When_Deserialize_ExpectToEqual(string hashString, long? height, string json)
         {
             // Setup
-            var exprectedHh = new HashHeight(Hash.Parse(hashString), height);
+            var exprectedHh = new HashHeight(Hash.Parse(hashString), (ulong?)height);
 
             // Execute
             var hh = new HashHeight(JsonConvert.DeserializeObject<JHashHeight>(json));

--- a/src/Zenon/Model/Embedded/GetRequiredResponse.cs
+++ b/src/Zenon/Model/Embedded/GetRequiredResponse.cs
@@ -4,9 +4,9 @@ namespace Zenon.Model.Embedded
 {
     public class GetRequiredResponse : IJsonConvertible<JGetRequiredResponse>
     {
-        public long AvailablePlasma { get; }
-        public long BasePlasma { get; }
-        public long RequiredDifficulty { get; }
+        public ulong AvailablePlasma { get; }
+        public ulong BasePlasma { get; }
+        public ulong RequiredDifficulty { get; }
 
         public GetRequiredResponse(JGetRequiredResponse json)
         {

--- a/src/Zenon/Model/Embedded/Json/JGetRequiredResponse.cs
+++ b/src/Zenon/Model/Embedded/Json/JGetRequiredResponse.cs
@@ -2,8 +2,8 @@
 {
     public class JGetRequiredResponse
     {
-        public long availablePlasma { get; set; }
-        public long basePlasma { get; set; }
-        public long requiredDifficulty { get; set; }
+        public ulong availablePlasma { get; set; }
+        public ulong basePlasma { get; set; }
+        public ulong requiredDifficulty { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/AccountBlock.cs
+++ b/src/Zenon/Model/NoM/AccountBlock.cs
@@ -19,8 +19,8 @@ namespace Zenon.Model.NoM
         }
 
         public AccountBlock[] DescendantBlocks { get; }
-        public long BasePlasma { get; }
-        public long UsedPlasma { get; }
+        public ulong BasePlasma { get; }
+        public ulong UsedPlasma { get; }
         public Hash ChangesHash { get; }
         public Token Token { get; }
         // Available if account-block is confirmed, null otherwise

--- a/src/Zenon/Model/NoM/AccountBlockConfirmationDetail.cs
+++ b/src/Zenon/Model/NoM/AccountBlockConfirmationDetail.cs
@@ -13,10 +13,10 @@ namespace Zenon.Model.NoM
             MomentumTimestamp = json.momentumTimestamp;
         }
 
-        public long NumConfirmations { get; }
-        public long MomentumHeight { get; }
+        public ulong NumConfirmations { get; }
+        public ulong MomentumHeight { get; }
         public Hash MomentumHash { get; }
-        public long MomentumTimestamp { get; }
+        public ulong MomentumTimestamp { get; }
 
         public virtual JAccountBlockConfirmationDetail ToJson()
         {

--- a/src/Zenon/Model/NoM/AccountBlockList.cs
+++ b/src/Zenon/Model/NoM/AccountBlockList.cs
@@ -14,14 +14,14 @@ namespace Zenon.Model.NoM
             More = json.more;
         }
 
-        public AccountBlockList(long count, AccountBlock[] list, bool more)
+        public AccountBlockList(ulong count, AccountBlock[] list, bool more)
         {
             Count = count;
             List = list;
             More = more;
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public AccountBlock[] List { get; }
 
         /// If true, there are more than `count` elements, but only these can be retrieved

--- a/src/Zenon/Model/NoM/AccountBlockTemplate.cs
+++ b/src/Zenon/Model/NoM/AccountBlockTemplate.cs
@@ -76,13 +76,13 @@ namespace Zenon.Model.NoM
             Signature = new byte[0];
         }
 
-        public int Version { get; }
-        public int ChainIdentifier { get; }
+        public ulong Version { get; }
+        public ulong ChainIdentifier { get; }
         public BlockTypeEnum BlockType { get; }
 
         public Hash Hash { get; internal set; }
         public Hash PreviousHash { get; internal set; }
-        public long Height { get; internal set; }
+        public ulong Height { get; internal set; }
         public HashHeight MomentumAcknowledged { get; internal set; }
 
         public Address Address { get; set; }
@@ -99,8 +99,8 @@ namespace Zenon.Model.NoM
         public byte[] Data { get; }
 
         // PoW
-        public long FusedPlasma { get; internal set; }
-        public long Difficulty { get; internal set; }
+        public ulong FusedPlasma { get; internal set; }
+        public ulong Difficulty { get; internal set; }
 
         // Hex representation of 8 byte nonce
         public string Nonce { get; internal set; }
@@ -120,7 +120,7 @@ namespace Zenon.Model.NoM
         {
             json.version = this.Version;
             json.chainIdentifier = this.ChainIdentifier;
-            json.blockType = (int)this.BlockType;
+            json.blockType = (ulong)this.BlockType;
             json.hash = this.Hash.ToString();
             json.previousHash = this.PreviousHash.ToString();
             json.height = this.Height;

--- a/src/Zenon/Model/NoM/AccountHeader.cs
+++ b/src/Zenon/Model/NoM/AccountHeader.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.NoM
             Height = json.height;
         }
 
-        public AccountHeader(Hash hash, long? height)
+        public AccountHeader(Hash hash, ulong? height)
         {
             Hash = hash;
             Height = height;
@@ -22,7 +22,7 @@ namespace Zenon.Model.NoM
         /// Added here for simplicity. Is not part of the RPC response.
         public Address Address { get; }
         public Hash Hash { get; }
-        public long? Height { get; }
+        public ulong? Height { get; }
 
         public virtual JAccountHeader ToJson()
         {

--- a/src/Zenon/Model/NoM/AccountInfo.cs
+++ b/src/Zenon/Model/NoM/AccountInfo.cs
@@ -9,7 +9,7 @@ namespace Zenon.Model.NoM
     public class AccountInfo : IJsonConvertible<JAccountInfo>
     {
         public string Address { get; }
-        public long? BlockCount { get; }
+        public ulong? BlockCount { get; }
         public BalanceInfoListItem[] BalanceInfoList { get; }
 
         public AccountInfo(JAccountInfo json)
@@ -21,7 +21,7 @@ namespace Zenon.Model.NoM
                 : new BalanceInfoListItem[0];
         }
 
-        public AccountInfo(string address, long? blockCount, BalanceInfoListItem[] balanceInfoList)
+        public AccountInfo(string address, ulong? blockCount, BalanceInfoListItem[] balanceInfoList)
         {
             Address = address;
             BlockCount = blockCount;

--- a/src/Zenon/Model/NoM/Json/JAccountBlock.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountBlock.cs
@@ -3,8 +3,8 @@
     public class JAccountBlock : JAccountBlockTemplate
     {
         public JAccountBlock[] descendantBlocks { get; set; }
-        public long basePlasma { get; set; }
-        public long usedPlasma { get; set; }
+        public ulong basePlasma { get; set; }
+        public ulong usedPlasma { get; set; }
         public string changesHash { get; set; }
         public JToken token { get; set; }
         public JAccountBlockConfirmationDetail confirmationDetail { get; set; }

--- a/src/Zenon/Model/NoM/Json/JAccountBlockConfirmationDetail.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountBlockConfirmationDetail.cs
@@ -2,9 +2,9 @@
 {
     public class JAccountBlockConfirmationDetail
     {
-        public long numConfirmations { get; set; }
-        public long momentumHeight { get; set; }
+        public ulong numConfirmations { get; set; }
+        public ulong momentumHeight { get; set; }
         public string momentumHash { get; set; }
-        public long momentumTimestamp { get; set; }
+        public ulong momentumTimestamp { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JAccountBlockList.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountBlockList.cs
@@ -3,7 +3,7 @@
     public class JAccountBlockList
     {
         public JAccountBlock[] list { get; set; }
-        public long count { get; set; }
+        public ulong count { get; set; }
         public bool more { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JAccountBlockTemplate.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountBlockTemplate.cs
@@ -4,12 +4,12 @@ namespace Zenon.Model.NoM.Json
 {
     public class JAccountBlockTemplate
     {
-        public int version { get; set; }
-        public int chainIdentifier { get; set; }
-        public int blockType { get; set; }
+        public ulong version { get; set; }
+        public ulong chainIdentifier { get; set; }
+        public ulong blockType { get; set; }
         public string hash { get; set; }
         public string previousHash { get; set; }
-        public long height { get; set; }
+        public ulong height { get; set; }
         public JHashHeight momentumAcknowledged { get; set; }
         public string address { get; set; }
         public string toAddress { get; set; }
@@ -17,8 +17,8 @@ namespace Zenon.Model.NoM.Json
         public string tokenStandard { get; set; }
         public string fromBlockHash { get; set; }
         public string data { get; set; }
-        public long fusedPlasma { get; set; }
-        public long difficulty { get; set; }
+        public ulong fusedPlasma { get; set; }
+        public ulong difficulty { get; set; }
         public string nonce { get; set; }
         public string publicKey { get; set; }
         public string signature { get; set; }

--- a/src/Zenon/Model/NoM/Json/JAccountHeader.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountHeader.cs
@@ -4,6 +4,6 @@
     {
         public string address { get; set; }
         public string hash { get; set; }
-        public long? height { get; set; }
+        public ulong? height { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JAccountInfo.cs
+++ b/src/Zenon/Model/NoM/Json/JAccountInfo.cs
@@ -5,7 +5,7 @@ namespace Zenon.Model.NoM.Json
     public class JAccountInfo
     {
         public string address { get; set; }
-        public long? accountHeight { get; set; }
+        public ulong? accountHeight { get; set; }
         public IDictionary<string, JBalanceInfoListItem> balanceInfoMap { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JMomentum.cs
+++ b/src/Zenon/Model/NoM/Json/JMomentum.cs
@@ -2,12 +2,12 @@
 {
     public class JMomentum
     {
-        public int version { get; set; }
-        public int chainIdentifier { get; set; }
+        public ulong version { get; set; }
+        public ulong chainIdentifier { get; set; }
         public string hash { get; set; }
         public string previousHash { get; set; }
-        public long height { get; set; }
-        public long timestamp { get; set; }
+        public ulong height { get; set; }
+        public ulong timestamp { get; set; }
         public string data { get; set; }
         public JAccountHeader[] content { get; set; }
         public string changesHash { get; set; }

--- a/src/Zenon/Model/NoM/Json/JMomentumList.cs
+++ b/src/Zenon/Model/NoM/Json/JMomentumList.cs
@@ -3,6 +3,6 @@
     public class JMomentumList
     {
         public JMomentum[] list { get; set; }
-        public long count { get; set; }
+        public ulong count { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JMomentumShort.cs
+++ b/src/Zenon/Model/NoM/Json/JMomentumShort.cs
@@ -3,7 +3,7 @@
     public class JMomentumShort
     {
         public string hash { get; set; }
-        public long? height { get; set; }
-        public long? timestamp { get; set; }
+        public ulong? height { get; set; }
+        public ulong? timestamp { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Json/JTokenList.cs
+++ b/src/Zenon/Model/NoM/Json/JTokenList.cs
@@ -2,7 +2,7 @@
 {
     public class JTokenList
     {
-        public long count { get; set; }
+        public ulong count { get; set; }
         public JToken[] list { get; set; }
     }
 }

--- a/src/Zenon/Model/NoM/Momentum.cs
+++ b/src/Zenon/Model/NoM/Momentum.cs
@@ -23,12 +23,12 @@ namespace Zenon.Model.NoM
             Producer = Address.Parse(json.producer);
         }
 
-        public int Version { get; }
-        public int ChainIdentifier { get; }
+        public ulong Version { get; }
+        public ulong ChainIdentifier { get; }
         public Hash Hash { get; }
         public Hash PreviousHash { get; }
-        public long Height { get; }
-        public long Timestamp { get; }
+        public ulong Height { get; }
+        public ulong Timestamp { get; }
         public byte[] Data { get; }
         public AccountHeader[] Content { get; }
         public Hash ChangesHash { get; }

--- a/src/Zenon/Model/NoM/MomentumList.cs
+++ b/src/Zenon/Model/NoM/MomentumList.cs
@@ -13,7 +13,7 @@ namespace Zenon.Model.NoM
                 : new Momentum[0];
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public Momentum[] List { get; }
 
         public virtual JMomentumList ToJson()

--- a/src/Zenon/Model/NoM/MomentumShort.cs
+++ b/src/Zenon/Model/NoM/MomentumShort.cs
@@ -13,8 +13,8 @@ namespace Zenon.Model.NoM
         }
 
         public Hash Hash { get; }
-        public long? Height { get; }
-        public long? Timestamp { get; }
+        public ulong? Height { get; }
+        public ulong? Timestamp { get; }
 
         public virtual JMomentumShort ToJson()
         {

--- a/src/Zenon/Model/NoM/TokenList.cs
+++ b/src/Zenon/Model/NoM/TokenList.cs
@@ -5,19 +5,19 @@ namespace Zenon.Model.NoM
 {
     public class TokenList : IJsonConvertible<JTokenList>
     {
-        public TokenList(Json.JTokenList json)
+        public TokenList(JTokenList json)
         {
             Count = json.count;
             List = json.list != null ? json.list.Select(x => new Token(x)).ToArray() : new Token[0];
         }
 
-        public TokenList(long count, Token[] list)
+        public TokenList(ulong count, Token[] list)
         {
             Count = count;
             List = list;
         }
 
-        public long Count { get; }
+        public ulong Count { get; }
         public Token[] List { get; }
 
         public virtual JTokenList ToJson()

--- a/src/Zenon/Model/Primitives/HashHeight.cs
+++ b/src/Zenon/Model/Primitives/HashHeight.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Zenon.Model.Primitives.Json;
 using Zenon.Utils;
 
 namespace Zenon.Model.Primitives
@@ -7,20 +8,20 @@ namespace Zenon.Model.Primitives
     {
         public static readonly HashHeight Empty = new HashHeight(Hash.Empty, 0);
 
-        public HashHeight(Json.JHashHeight json)
+        public HashHeight(JHashHeight json)
         {
             Hash = Hash.Parse(json.hash);
             Height = json.height;
         }
 
-        public HashHeight(Hash hash, long? height)
+        public HashHeight(Hash hash, ulong? height)
         {
             Hash = hash;
             Height = height;
         }
 
         public Hash Hash { get; }
-        public long? Height { get; }
+        public ulong? Height { get; }
 
         public byte[] GetBytes()
         {

--- a/src/Zenon/Model/Primitives/Json/JHashHeight.cs
+++ b/src/Zenon/Model/Primitives/Json/JHashHeight.cs
@@ -3,6 +3,6 @@
     public class JHashHeight
     {
         public string hash { get; set; }
-        public long? height { get; set; }
+        public ulong? height { get; set; }
     }
 }

--- a/src/Zenon/Pow/PoW.cs
+++ b/src/Zenon/Pow/PoW.cs
@@ -14,7 +14,7 @@ namespace Zenon.Pow
         private const int DataSize = 40;
         private static readonly SHA3.Net.Sha3 shaAlg = SHA3.Net.Sha3.Sha3256();
 
-        public static async Task<string> Generate(Hash hash, long difficulty)
+        public static async Task<string> Generate(Hash hash, ulong difficulty)
         {
             return await Task.Run(() =>
             {
@@ -22,7 +22,7 @@ namespace Zenon.Pow
             });
         }
 
-        public static async Task<string> Benchmark(long difficulty)
+        public static async Task<string> Benchmark(ulong difficulty)
         {
             return await Task.Run(() =>
             {
@@ -30,7 +30,7 @@ namespace Zenon.Pow
             });
         }
 
-        private static byte[] GenerateInternal(byte[] hash, long difficulty)
+        private static byte[] GenerateInternal(byte[] hash, ulong difficulty)
         {
             var target = GetTarget(difficulty);
             var entropy = GetRandomSeed();
@@ -52,7 +52,7 @@ namespace Zenon.Pow
             }
         }
 
-        private static byte[] BenchmarkInternal(long difficulty)
+        private static byte[] BenchmarkInternal(ulong difficulty)
         {
             var target = GetTarget(difficulty);
             var data = GetData(new byte[OutSize], new byte[InSize]);
@@ -80,7 +80,7 @@ namespace Zenon.Pow
             Array.Copy(digest, hash, 8);
         }
 
-        private static byte[] GetTarget(long difficulty)
+        private static byte[] GetTarget(ulong difficulty)
         {
             // set big to 1 << 64
             var big = new BigInteger(1L << 62);

--- a/src/Zenon/Utils/BlockUtils.cs
+++ b/src/Zenon/Utils/BlockUtils.cs
@@ -80,7 +80,7 @@ namespace Zenon.Utils
             var frontierAccountBlock =
                 await Znn.Instance.Ledger.GetFrontierAccountBlock(accountBlockTemplate.Address);
 
-            long height = 1;
+            ulong height = 1;
             Hash previousHash = Hash.Empty;
 
             if (frontierAccountBlock != null)

--- a/src/Zenon/Utils/BytesUtils.cs
+++ b/src/Zenon/Utils/BytesUtils.cs
@@ -59,7 +59,17 @@ namespace Zenon.Utils
             return EndianBitConverter.Big.GetBytes(value);
         }
 
+        public static byte[] GetBytes(uint value)
+        {
+            return EndianBitConverter.Big.GetBytes(value);
+        }
+
         public static byte[] GetBytes(long value)
+        {
+            return EndianBitConverter.Big.GetBytes(value);
+        }
+
+        public static byte[] GetBytes(ulong value)
         {
             return EndianBitConverter.Big.GetBytes(value);
         }

--- a/src/Zenon/Znn.cs
+++ b/src/Zenon/Znn.cs
@@ -12,8 +12,8 @@ namespace Zenon
     {
         public static Znn Instance = new Znn();
 
-        public int NetworkIdentifier { get; }
-        public int ChainIdentifier { get; set; }
+        public ulong NetworkIdentifier { get; }
+        public ulong ChainIdentifier { get; set; }
 
         public KeyPair DefaultKeyPair { get; set; }
         public KeyStore DefaultKeyStore { get; set; }


### PR DESCRIPTION
Not all data type definitions were equal and could cause possible overflows. See  #9.

All definitions have been checked and aligned with the go-zenon definitions.